### PR TITLE
Update artefact name from com.redhat.lightblue.client group

### DIFF
--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -62,7 +62,7 @@
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.client</groupId>
-            <artifactId>http</artifactId>
+            <artifactId>lightblue-client-http</artifactId>
             <version>1.2.0-SNAPSHOT</version>
         </dependency>
 


### PR DESCRIPTION
The name has changed https://github.com/lightblue-platform/lightblue-client/blame/master/http/pom.xml#L9  and https://github.com/lightblue-platform/lightblue-client/issues/67#issuecomment-81664012
