### PR TITLE
provide a lightblue-client.properties file that clients can alternativly load from

### DIFF
--- a/test-utils/src/main/java/com/redhat/lightblue/test/utils/AbstractCRUDControllerWithRest.java
+++ b/test-utils/src/main/java/com/redhat/lightblue/test/utils/AbstractCRUDControllerWithRest.java
@@ -31,12 +31,26 @@ public abstract class AbstractCRUDControllerWithRest extends AbstractMongoCRUDTe
     private static HttpServer httpServer;
 
     private final int httpPort;
+    private final String dataUrl;
+    private final String metadataUrl;
 
     @AfterClass
     public static void stopHttpServer() {
         if (httpServer != null) {
             httpServer.stop(0);
         }
+    }
+
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    public String getDataUrl() {
+        return dataUrl;
+    }
+
+    public String getMetadataUrl() {
+        return metadataUrl;
     }
 
     public AbstractCRUDControllerWithRest() throws Exception {
@@ -53,6 +67,10 @@ public abstract class AbstractCRUDControllerWithRest extends AbstractMongoCRUDTe
     public AbstractCRUDControllerWithRest(int httpServerPort) throws Exception {
         super();
         httpPort = httpServerPort;
+        dataUrl = "http://localhost:" + httpPort + "/rest/data";
+        metadataUrl = "http://localhost:" + httpPort + "/rest/metadata";
+        System.setProperty("client.data.url", getDataUrl());
+        System.setProperty("client.metadata.url", getMetadataUrl());
 
         if (httpServer == null) {
             RestConfiguration.setFactory(getLightblueFactory());
@@ -80,8 +98,8 @@ public abstract class AbstractCRUDControllerWithRest extends AbstractMongoCRUDTe
     protected LightblueClientConfiguration getLightblueClientConfiguration() {
         LightblueClientConfiguration lbConf = new LightblueClientConfiguration();
         lbConf.setUseCertAuth(false);
-        lbConf.setDataServiceURI("http://localhost:" + httpPort + "/rest/data");
-        lbConf.setMetadataServiceURI("http://localhost:" + httpPort + "/rest/metadata");
+        lbConf.setDataServiceURI(getDataUrl());
+        lbConf.setMetadataServiceURI(getMetadataUrl());
         return lbConf;
     }
 

--- a/test-utils/src/main/resources/lightblue-client.properties
+++ b/test-utils/src/main/resources/lightblue-client.properties
@@ -1,0 +1,3 @@
+metadataServiceURI=${client.metadata.url}
+dataServiceURI=${client.data.url}
+useCertAuth=false

--- a/test-utils/src/main/resources/lightblue-metadata.json
+++ b/test-utils/src/main/resources/lightblue-metadata.json
@@ -1,6 +1,0 @@
-{
-    "validateRequests" : false,
-    "type": "com.redhat.lightblue.mongo.config.MongoMetadataConfiguration",
-    "dataSource": "mongo",
-    "collection": "metadata"
-}


### PR DESCRIPTION
Some clients may want to be configured using a configuration file (_cough_ migrator). This provides that option.

Also lightblue-metadata.json was unused, so I removed it.

Depends on https://github.com/lightblue-platform/lightblue-client/pull/96
